### PR TITLE
Create transaction using pix payment method

### DIFF
--- a/lib/Transaction/PixTransaction.php
+++ b/lib/Transaction/PixTransaction.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PagarMe\Sdk\Transaction;
+
+class PixTransaction extends AbstractTransaction
+{
+    const PAYMENT_METHOD = 'pix';
+
+    /**
+     * @var string
+     */
+    protected $pixQrcode;
+
+    /**
+     * @var \DateTime
+     */
+    protected $pixExpirationDate;
+
+    /**
+     * @var array
+     */
+    protected $pixAdditionalFields;
+
+    /**
+     * @param array $transactionData
+     */
+    public function __construct($transactionData)
+    {
+        parent::__construct($transactionData);
+        $this->paymentMethod = self::PAYMENT_METHOD;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPixQrcode()
+    {
+        return $this->pixQrcode;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getPixExpirationDate()
+    {
+        return $this->pixExpirationDate;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPixAdditionalFields()
+    {
+        return $this->pixAdditionalFields;
+    }
+}

--- a/lib/Transaction/Request/PixTransactionCreate.php
+++ b/lib/Transaction/Request/PixTransactionCreate.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PagarMe\Sdk\Transaction\Request;
+
+
+use PagarMe\Sdk\Transaction\PixTransaction;
+
+class PixTransactionCreate extends TransactionCreate
+{
+    /**
+     * @param PixTransaction $transaction
+     */
+    public function __construct(PixTransaction $transaction)
+    {
+        $this->transaction = $transaction;
+    }
+
+    /**
+     * return array
+     */
+    public function getPayload()
+    {
+        $basicData = parent::getPayload();
+
+        $pixData = [
+            'pix_expiration_date' => $this->transaction->getPixExpirationDate(),
+            'pix_additional_fields' => $this->transaction->getPixAdditionalFields()
+        ];
+
+        return array_merge($basicData, $pixData);
+    }
+}

--- a/lib/Transaction/TransactionBuilder.php
+++ b/lib/Transaction/TransactionBuilder.php
@@ -54,6 +54,14 @@ trait TransactionBuilder
             return new CreditCardTransaction(get_object_vars($transactionData));
         }
 
+        if ($transactionData->payment_method == PixTransaction::PAYMENT_METHOD) {
+            $transactionData->pix_expiration_date = new \DateTime(
+                $transactionData->pix_expiration_date
+            );
+
+            return new PixTransaction(get_object_vars($transactionData));
+        }
+
         throw new UnsupportedTransaction(
             sprintf(
                 'Transaction type: %s, is not supported',

--- a/lib/Transaction/TransactionHandler.php
+++ b/lib/Transaction/TransactionHandler.php
@@ -7,6 +7,7 @@ use PagarMe\Sdk\Client;
 use PagarMe\Sdk\Payable\PayableBuilder;
 use PagarMe\Sdk\Transaction\Request\CreditCardTransactionCreate;
 use PagarMe\Sdk\Transaction\Request\BoletoTransactionCreate;
+use PagarMe\Sdk\Transaction\Request\PixTransactionCreate;
 use PagarMe\Sdk\Transaction\Request\TransactionGet;
 use PagarMe\Sdk\Transaction\Request\TransactionList;
 use PagarMe\Sdk\Transaction\Request\TransactionCapture;
@@ -96,6 +97,44 @@ class TransactionHandler extends AbstractHandler
         $transaction = new BoletoTransaction($transactionData);
 
         $request = new BoletoTransactionCreate($transaction);
+
+        $response = $this->client->send($request);
+
+        return $this->buildTransaction($response);
+    }
+
+    /**
+     * @param int                            $amount
+     * @param \PagarMe\Sdk\Customer\Customer $customer
+     * @param                                $postBackUrl
+     * @param                                $pixExpirationDate
+     * @param array                          $pixAdditionalFields
+     * @param null                           $metadata
+     *
+     * @return \PagarMe\Sdk\Transaction\PixTransaction
+     * @throws \PagarMe\Sdk\ClientException
+     * @throws \PagarMe\Sdk\Transaction\UnsupportedTransaction
+     */
+    public function pixTransaction(
+        $amount,
+        Customer $customer,
+        $postBackUrl,
+        $pixExpirationDate,
+        $pixAdditionalFields = [],
+        $metadata = null
+    ) {
+        $transactionData = [
+            'amount'                => $amount,
+            'customer'              => $customer,
+            'postbackUrl'           => $postBackUrl,
+            'pixExpirationDate'     => $pixExpirationDate,
+            'pixAdditionalFields'   => $pixAdditionalFields,
+            'metadata'              => $metadata
+        ];
+
+        $transaction = new PixTransaction($transactionData);
+
+        $request = new PixTransactionCreate($transaction);
 
         $response = $this->client->send($request);
 

--- a/tests/unit/Transaction/Request/PixTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/PixTransactionCreateTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace PagarMe\SdkTest\Transaction\Request;
+
+use PagarMe\Sdk\Transaction\PixTransaction;
+use PagarMe\Sdk\Transaction\Request\BoletoTransactionCreate;
+use PagarMe\Sdk\Transaction\BoletoTransaction;
+use PagarMe\Sdk\SplitRule\SplitRuleCollection;
+use PagarMe\Sdk\SplitRule\SplitRule;
+use PagarMe\Sdk\Recipient\Recipient;
+use PagarMe\Sdk\RequestInterface;
+use PagarMe\Sdk\Transaction\Request\PixTransactionCreate;
+
+class PixTransactionCreateTest extends \PHPUnit_Framework_TestCase
+{
+    use FakeReferenceKey;
+
+    const PATH   = 'transactions';
+
+    public function boletoOptions()
+    {
+        return [
+            [null, null],
+            [date('Y-m-d', strtotime("tomorrow")), [['name' => 'first', 'value' => 'test'], ['name' => 'second', 'value' => 'test']]],
+            [date('Y-m-d', strtotime("+15 days")), []]
+        ];
+    }
+
+    /**
+     * @dataProvider boletoOptions
+     * @test
+     */
+    public function mustPayloadBeCorrect($expirationDate, $additionalFields)
+    {
+        $transaction = $this->createTransaction($expirationDate, $additionalFields);
+        $transactionCreate = new PixTransactionCreate($transaction);
+
+        $this->assertEquals(
+            [
+                'amount'                 => 1337,
+                'payment_method'         => 'pix',
+                'postback_url'           => 'example.com/postback',
+                'metadata'               => null,
+                'customer' => [
+                    'name'            => 'Eduardo Nascimento',
+                    'born_at'         => '15071991',
+                    'document_number' => '10586649727',
+                    'email'           => 'eduardo@eduardo.com',
+                    'sex'             => 'M',
+                    'address' => [
+                        'street'        => 'rua teste',
+                        'street_number' => 42,
+                        'neighborhood'  => 'centro',
+                        'zipcode'       => '01227200',
+                        'complementary' => null
+                    ],
+                    'phone' => [
+                        'ddi'    => 55,
+                        'ddd'    => 15,
+                        'number' => 987523421
+                    ]
+                ],
+                'pix_expiration_date'    => $expirationDate,
+                'pix_additional_fields'  => $additionalFields,
+                'reference_key'          => null
+            ],
+            $transactionCreate->getPayload()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustPayloadContainSplitRule()
+    {
+        $customerMock = $this->getCustomerMock();
+
+        $rules = new SplitRuleCollection();
+        $rules[]= new SplitRule([
+            'amount'                => 100,
+            'recipient'             => new Recipient(['id' => 1]),
+            'liable'                => true,
+            'charge_processing_fee' => true
+        ]);
+        $rules[]= new SplitRule([
+            'percentage'            => 10,
+            'recipient'             => new Recipient(['id' => 3]),
+            'liable'                => false,
+            'charge_processing_fee' => false
+        ]);
+
+        $expirationDate = strtotime("tomorrow");
+
+        $transaction =  new PixTransaction(
+            [
+                'amount'                 => 1337,
+                'postback_url'           => 'example.com/postback',
+                'pix_expiration_date'    => $expirationDate,
+                'customer'               => $customerMock,
+                'split_rules'            => $rules
+            ]
+        );
+
+        $transactionCreate = new PixTransactionCreate(
+            $transaction,
+            null,
+            null,
+            ['splitRules' => $rules]
+        );
+
+        $this->assertEquals(
+            [
+                'amount'                 => 1337,
+                'payment_method'         => 'pix',
+                'postback_url'           => 'example.com/postback',
+                'metadata'               => null,
+                'customer' => [
+                    'name'            => 'Eduardo Nascimento',
+                    'born_at'         => '15071991',
+                    'document_number' => '10586649727',
+                    'email'           => 'eduardo@eduardo.com',
+                    'sex'             => 'M',
+                    'address' => [
+                        'street'        => 'rua teste',
+                        'street_number' => 42,
+                        'neighborhood'  => 'centro',
+                        'zipcode'       => '01227200',
+                        'complementary' => null
+                    ],
+                    'phone' => [
+                        'ddi'    => 55,
+                        'ddd'    => 15,
+                        'number' => 987523421
+                    ]
+                ],
+                'pix_expiration_date'    => $expirationDate,
+                'pix_additional_fields'  => null,
+                'reference_key'          => null,
+                'split_rules' => [
+                    0 => [
+                        'amount'                => 100,
+                        'recipient_id'          => 1,
+                        'liable'                => true,
+                        'charge_processing_fee' => true
+                    ],
+                    1 => [
+                        'percentage'            => 10,
+                        'recipient_id'          => 3,
+                        'liable'                => false,
+                        'charge_processing_fee' => false
+                    ]
+                ]
+            ],
+            $transactionCreate->getPayload()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mustPathBeCorrect()
+    {
+        $transaction =  $this->getMockBuilder('PagarMe\Sdk\Transaction\PixTransaction')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transactionCreate = new PixTransactionCreate($transaction);
+
+        $this->assertEquals(self::PATH, $transactionCreate->getPath());
+    }
+
+    /**
+     * @test
+     */
+    public function mustMethodBeCorrect()
+    {
+        $transaction =  $this->getMockBuilder('PagarMe\Sdk\Transaction\PixTransaction')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $transactionCreate = new PixTransactionCreate($transaction);
+
+        $this->assertEquals(RequestInterface::HTTP_POST, $transactionCreate->getMethod());
+    }
+
+    private function createTransaction(
+        $expirationDate,
+        $additionalFields = []
+    ) {
+        $customerMock = $this->getCustomerMock();
+
+        $transaction =  new PixTransaction(
+            [
+                'amount'                => 1337,
+                'postback_url'          => 'example.com/postback',
+                'customer'              => $customerMock,
+                'pix_expiration_date'   => $expirationDate,
+                'pix_additional_fields' => $additionalFields
+            ]
+        );
+
+        return $transaction;
+    }
+
+    public function getCustomerMock()
+    {
+        $customerMock = $this->getMockBuilder('PagarMe\Sdk\Customer\Customer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $customerMock->method('getBornAt')->willReturn('15071991');
+        $customerMock->method('getDocumentNumber')->willReturn('10586649727');
+        $customerMock->method('getEmail')->willReturn('eduardo@eduardo.com');
+        $customerMock->method('getGender')->willReturn('M');
+        $customerMock->method('getName')->willReturn('Eduardo Nascimento');
+        $customerMock->method('getAddress')->willReturn(
+            [
+                'street'        => 'rua teste',
+                'street_number' => 42,
+                'neighborhood'  => 'centro',
+                'zipcode'       => '01227200'
+            ]
+        );
+        $customerMock->method('getPhone')->willReturn(
+            [
+                'ddi'    => 55,
+                'ddd'    => 15,
+                'number' => 987523421
+            ]
+        );
+
+        return $customerMock;
+    }
+}

--- a/tests/unit/Transaction/Request/PixTransactionCreateTest.php
+++ b/tests/unit/Transaction/Request/PixTransactionCreateTest.php
@@ -15,7 +15,7 @@ class PixTransactionCreateTest extends \PHPUnit_Framework_TestCase
 {
     use FakeReferenceKey;
 
-    const PATH   = 'transactions';
+    const PATH = 'transactions';
 
     public function boletoOptions()
     {

--- a/tests/unit/Transaction/TransactionBuilderTest.php
+++ b/tests/unit/Transaction/TransactionBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Pagarme\SdkTests\Transaction;
 
+use PagarMe\Sdk\Transaction\PixTransaction;
 use PagarMe\Sdk\Transaction\TransactionHandler;
 use PagarMe\Sdk\Transaction\AbstractTransaction;
 use PagarMe\Sdk\Transaction\BoletoTransaction;
@@ -70,6 +71,36 @@ class TransactionBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function mustCreatePixTransaction()
+    {
+
+        $transaction = $this->buildTransaction(
+            json_decode(
+                $this->pixTransactionCreateResponse()
+            )
+        );
+
+        $this->assertInstanceOf(
+            'PagarMe\Sdk\Transaction\PixTransaction',
+            $transaction
+        );
+
+        $this->assertInstanceOf('\DateTime', $transaction->getDateCreated());
+        $this->assertInstanceOf('\DateTime', $transaction->getDateUpdated());
+        $this->assertInstanceOf('\DateTime', $transaction->getPixExpirationDate());
+        $this->assertInstanceOf(
+            'PagarMe\Sdk\SplitRule\SplitRuleCollection',
+            $transaction->getSplitRules()
+        );
+        $this->assertEquals(
+            PixTransaction::PAYMENT_METHOD,
+            $transaction->getPaymentMethod()
+        );
+    }
+
+    /**
+     * @test
      * @expectedException PagarMe\Sdk\Transaction\UnsupportedTransaction
      */
     public function mustThrowUnsupportedTransaction()
@@ -88,5 +119,11 @@ class TransactionBuilderTest extends \PHPUnit_Framework_TestCase
     {
         // @codingStandardsIgnoreLine
         return '{"object":"transaction","status":"waiting_payment","refuse_reason":null,"status_reason":"acquirer","acquirer_response_code":null,"acquirer_name":"pagarme","authorization_code":null,"soft_descriptor":null,"tid":733692,"nsu":733692,"date_created":"2016-09-26T19:14:35.119Z","date_updated":"2016-09-26T19:14:35.281Z","amount":3100,"authorized_amount":3100,"paid_amount":0,"refunded_amount":0,"installments":1,"id":733692,"cost":0,"card_holder_name":null,"card_last_digits":null,"card_first_digits":null,"card_brand":null,"postback_url":null,"payment_method":"boleto","capture_method":"ecommerce","antifraud_score":null,"boleto_url":"https://pagar.me","boleto_barcode":"1234 5678","boleto_expiration_date":"2016-10-03T03:00:00.117Z","referer":"api_key","ip":"187.11.121.49","subscription_id":null,"phone":null,"address":null,"customer":null,"card":null,"split_rules":[{"object":"split_rule","id":"sr_cixi05w5w04erhx6dllaght6m","recipient_id":"re_cixi05vxt04ephx6dxm1y0esy","charge_processing_fee":true,"charge_remainder":false,"liable":true,"percentage":49,"amount":null,"date_created":"2017-01-03T21:03:56.948Z","date_updated":"2017-01-03T21:03:56.948Z"},{"object":"split_rule","id":"sr_cixi05w5v04eqhx6d4ala4v4b","recipient_id":"re_cixi05vt4053fmm6etx9e7h9f","charge_processing_fee":true,"charge_remainder":true,"liable":true,"percentage":51,"amount":null,"date_created":"2017-01-03T21:03:56.947Z","date_updated":"2017-01-03T21:03:56.947Z"}],"metadata":{},"antifraud_metadata":{}}';
+    }
+
+    public function pixTransactionCreateResponse()
+    {
+        // @codingStandardsIgnoreLine
+        return '{"object":"transaction","status":"waiting_payment","refuse_reason":null,"status_reason":"acquirer","acquirer_response_code":null,"acquirer_name":"pagarme","authorization_code":null,"soft_descriptor":null,"tid":733692,"nsu":733692,"date_created":"2016-09-26T19:14:35.119Z","date_updated":"2016-09-26T19:14:35.281Z","amount":3100,"authorized_amount":3100,"paid_amount":0,"refunded_amount":0,"installments":1,"id":733692,"cost":0,"card_holder_name":null,"card_last_digits":null,"card_first_digits":null,"card_brand":null,"postback_url":null,"payment_method":"pix","capture_method":"ecommerce","antifraud_score":null,"pix_qrcode":"00020101021226480019BR.COM.STONE.QRCODE0108A37F8712020912345678927820014BR.GOV.BCB.PIX2560sandbox-qrcode.stone.com.br/api/v2/qr/sGY7FyVExavqkzFvkQuMXA28580010BR.COM.ELO0104516002151234567890000000308933BB1100401P520400 00530398654041.005802BR5911STONETESTE6009SAOPAULO62600522sGY7FyVExavqkzFvkQuMXA50300017BR.GOV.BCB.BRCODE01051.0.080500010BR.COM.ELO01100915132023020200030201040613202363043BA1","pix_expiration_date":"2016-09-26T19:14:35.119Z","pix_additional_fields":[{"name":"test 1","value":"foo"},{"name":"test 2","value":"bar"}],"referer":"api_key","ip":"187.11.121.49","subscription_id":null,"phone":null,"address":null,"customer":null,"card":null,"split_rules":[{"object":"split_rule","id":"sr_cixi05w5w04erhx6dllaght6m","recipient_id":"re_cixi05vxt04ephx6dxm1y0esy","charge_processing_fee":true,"charge_remainder":false,"liable":true,"percentage":49,"amount":null,"date_created":"2017-01-03T21:03:56.948Z","date_updated":"2017-01-03T21:03:56.948Z"},{"object":"split_rule","id":"sr_cixi05w5v04eqhx6d4ala4v4b","recipient_id":"re_cixi05vt4053fmm6etx9e7h9f","charge_processing_fee":true,"charge_remainder":true,"liable":true,"percentage":51,"amount":null,"date_created":"2017-01-03T21:03:56.947Z","date_updated":"2017-01-03T21:03:56.947Z"}],"metadata":{},"antifraud_metadata":{}}';
     }
 }


### PR DESCRIPTION
### Descrição

Criação de transações usando "pix" como método de pagamento.

### Testes Realizados
TransactionBuilderTest::pixTransactionCreateResponse
PixTransactionCreateTest::mustPayloadBeCorrect
PixTransactionCreateTest::mustPayloadContainSplitRule
PixTransactionCreateTest::mustPathBeCorrect
PixTransactionCreateTest::mustMethodBeCorrect

<!NÃO SE ESQUEÇA DE: Marcar um dos desenvolvedores do Pagar.me para review.>
