### PR TITLE
Fixing pagarme transaction API response typo

### DIFF
--- a/lib/Transaction/PixTransaction.php
+++ b/lib/Transaction/PixTransaction.php
@@ -9,7 +9,7 @@ class PixTransaction extends AbstractTransaction
     /**
      * @var string
      */
-    protected $pixQrcode;
+    protected $pixQrCode;
 
     /**
      * @var \DateTime
@@ -33,9 +33,9 @@ class PixTransaction extends AbstractTransaction
     /**
      * @return string
      */
-    public function getPixQrcode()
+    public function getPixQrCode()
     {
-        return $this->pixQrcode;
+        return $this->pixQrCode;
     }
 
     /**


### PR DESCRIPTION
### Descrição

Buscar da resposta da API o campo pix_qr_code em vez de pix_qrcode.